### PR TITLE
8th December 2023: 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## \[0.1.1\] - 2023-12-08
 
+### Added
+
+  - Added unit tests in `hashing.rs`.
+
 ### Changed
 
   - Changed from `std::process:ExitCode` to `anyhow::Result` for error handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - 2023-12-03
+## \[Unreleased\]
+
+## \[0.1.1\] - 2023-12-08
+
+### Changed
+
+  - Changed from `std::process:ExitCode` to `anyhow::Result` for error handling.
+  - Switched from using the `openssl` crate to `sha2` one, as `sha2` is more lightweight.
+
+## \[0.1.0\] - 2023-12-03
 
 ### Added
 
-- Initial release: Basic functionality to compute the SHA256 checksum and check it.
-
+  - Initial release: Basic functionality to compute the SHA256 checksum and check it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,18 +35,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitflags"
-version = "2.4.1"
+name = "block-buffer"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "libc",
+ "generic-array",
 ]
 
 [[package]]
@@ -57,7 +57,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags 1.3.2",
+ "bitflags",
  "strsim",
  "textwrap",
  "unicode-width",
@@ -65,19 +65,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "cpufeatures"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
 dependencies = [
- "foreign-types-shared",
+ "libc",
 ]
 
 [[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "heck"
@@ -110,66 +134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
-name = "once_cell"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "openssl"
-version = "0.10.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
-dependencies = [
- "bitflags 2.4.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "openssl-src"
-version = "300.1.6+3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,7 +142,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "version_check",
 ]
 
@@ -212,10 +176,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha256sum-rs"
 version = "0.1.0"
 dependencies = [
- "openssl",
+ "anyhow",
+ "sha2",
  "structopt",
 ]
 
@@ -246,7 +222,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -261,17 +237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +244,12 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-ident"
@@ -297,12 +268,6 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
+sha2 = "0.10"
 structopt = "0.3"
+anyhow = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sha256sum-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,62 +1,50 @@
 # sha256sum-win
 
-## Description
-
-`sha256sum-win` is a Windows port of the sha256sum command, providing the ability to print or check SHA256 (256-bit) checksums. Please note that this project is still under heavy development, and API-breaking changes are expected. As of now, development is not very active, and updates occur when time permits.
-
-## Features
-
-- Windows port of the sha256sum command
-- Print or check SHA256 checksums
-- Dual-licensed under Apache 2.0 or MIT license
+`sha256sum-win` is a port of the sha256sum command, written in Rust.
+**Disclaimer**: This project is still under heavy development, and breaking changes are expected.
 
 ## Installation
 
-Ensure you have [Rust](https://www.rust-lang.org/tools/install) installed. Clone the repository and run:
+Ensure you have [Rust](https://rustup.rs/) installed in order to compile the project. Clone the repository and run:
 
 ```bash
 cargo build --release
 ```
 
-## Usage
+## Usage: examples
 
-### Print SHA256 checksum
+Print SHA256 checksum:
 
-```bash
-sha256sum-win path/to/file
+```console
+$ sha256sum-win path/to/file
 ```
 
-### Check SHA256 checksum
+Check SHA256 checksum:
 
-```bash
-sha256sum-win --check path/to/checksum/file
+```console
+$ sha256sum-win --check path/to/checksum/file
 ```
-
-## Requirements
-
-- Rust (for building)
-- OpenSSL
 
 ## Support
 
-For help or suggestions, please open an [issue](https://github.com/walker84837/sha256sum-win/issues).
-
-## Roadmap
-
-No specific roadmap available at the moment.
+For help or suggestions, please open an [issue](https://github.com/walker84837/sha256sum-win-rs/issues).
 
 ## Contributing
 
-Contributions are welcome! If you want to contribute, please check the [Contributing Guidelines](CONTRIBUTING.md).
-
-## Authors and Acknowledgment
-
-- [walker84837](https://github.com/walker84837) - Sole developer
+Contributions are welcome! If you want to contribute, please:
+  - Try to use the least amount of `unsafe` blocks. If that's needed make some safe wrapper function around it.
+  - I recommend you to use Windows functions (`winapi` or `std::os::windows`) if performance will be better.
+  - Prefer using the standard library over reinventing the wheel.
+  - Format code with
+    ```console
+    rustfmt --edition 2021
+    ```
+  - If you would like to make big changes (eg. changing libraries for checksums or removing files), open an issue, explaining what you'd like to change, the main reasons as to why, and what is the difference between using it or not.
 
 ## License
 
-This project is dual-licensed under the [Apache 2.0](LICENSE-APACHE) and [MIT](LICENSE-MIT) licenses.
+This project is dual-licensed under the [Apache 2.0](LICENSE_APACHE.md) or [MIT](LICENSE_MIT.md) licenses.
 
 ## Project Status
 
-Development is not very active. Feel free to fork or contribute if interested.
+As of now, development is not very active, and updates occur when time permits. Feel free to contribute if interested.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Ensure you have [Rust](https://rustup.rs/) installed in order to compile the project. Clone the repository and run:
 
-```bash
+``` bash
 cargo build --release
 ```
 
@@ -15,14 +15,14 @@ cargo build --release
 
 Print SHA256 checksum:
 
-```console
+``` console
 $ sha256sum-win path/to/file
 ```
 
 Check SHA256 checksum:
 
-```console
-$ sha256sum-win --check path/to/checksum/file
+``` console
+$ sha256sum-win --check path/to/checksum/file.sha256
 ```
 
 ## Support
@@ -31,12 +31,13 @@ For help or suggestions, please open an [issue](https://github.com/walker84837/s
 
 ## Contributing
 
-Contributions are welcome! If you want to contribute, please:
+Contributions are welcome\! If you want to contribute, please:
+
   - Try to use the least amount of `unsafe` blocks. If that's needed make some safe wrapper function around it.
   - I recommend you to use Windows functions (`winapi` or `std::os::windows`) if performance will be better.
   - Prefer using the standard library over reinventing the wheel.
   - Format code with
-    ```console
+    ``` console
     rustfmt --edition 2021
     ```
   - If you would like to make big changes (eg. changing libraries for checksums or removing files), open an issue, explaining what you'd like to change, the main reasons as to why, and what is the difference between using it or not.

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -1,20 +1,28 @@
-use openssl::hash::{Hasher, MessageDigest};
-use std::fmt::Write;
+use sha2::{Digest, Sha256};
 
 pub struct Sha256Sum;
 
 impl Sha256Sum {
     pub fn get_checksum(data: &[u8]) -> String {
-        let mut hasher = Hasher::new(MessageDigest::sha256())
-            .expect("Failed to create a digest");
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        format!("{:x}", hasher.finalize())
+    }
+}
 
-        hasher.update(data).expect("Failed to update digest with data");
-        let result = hasher.finish().expect("Failed to generate checksum");
+mod tests {
+    // use super::*;
 
-        let mut checksum = String::with_capacity(result.len() * 2);
-        result.iter().for_each(|byte| {
-            write!(checksum, "{:02x}", byte).expect("Failed to write to string");
-        });
-        checksum
+    #[test]
+    fn test_checksum() {
+        use crate::hashing::Sha256Sum;
+
+        let data = b"i use arch btw\n";
+
+        let expected_checksum =
+            "80799b90f4c070668b52df31830b60ef767bb039000eec4266f285d498002bb5".to_owned();
+
+        let actual_checksum = Sha256Sum::get_checksum(data);
+        assert_eq!(actual_checksum, expected_checksum);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,14 @@
-use std::{
-    process::ExitCode,
-    fs::File,
-    io::Read,
-    path::PathBuf,
-};
+use anyhow::{Error, Result};
+use std::{fs::File, io::Read, path::PathBuf};
 use structopt::StructOpt;
 
 mod hashing;
 
-/// A Windows port of the sha256sum command: print or check SHA256 (256-bit) checksums.
 #[derive(StructOpt)]
-#[structopt(name = "sha256sum-win")]
+#[structopt(
+    name = "sha256sum-win",
+    about = "A Windows port of the sha256sum command: print or check SHA256 (256-bit) checksums."
+)]
 struct Args {
     /// The file's path.
     #[structopt(parse(from_os_str))]
@@ -20,7 +18,7 @@ struct Args {
     check: bool,
 }
 
-fn main() -> ExitCode {
+fn main() -> Result<()> {
     let opt = Args::from_args();
 
     let mut contents = Vec::new();
@@ -29,45 +27,40 @@ fn main() -> ExitCode {
         Ok(mut file) => {
             if let Err(e) = file.read_to_end(&mut contents) {
                 eprintln!("Error reading file {}: {}", opt.path.display(), e);
-                return ExitCode::FAILURE;
             }
         }
         Err(e) => {
             eprintln!("Error opening file {}: {}", opt.path.display(), e);
-            return ExitCode::FAILURE;
         }
     }
 
-    let checking = opt.check;
-
-    if !checking {
+    if !opt.check {
         let checksum: String = hashing::Sha256Sum::get_checksum(&contents);
         println!("{}  {}", checksum, opt.path.display());
+        return Ok(());
     } else {
         let contents_str = match std::str::from_utf8(&contents) {
             Ok(s) => s,
             Err(e) => {
-                eprintln!("Error converting binary data to string: {}", e);
-                return ExitCode::FAILURE;
+                let error_msg = format!("Error converting binary data to string: {}", e);
+                return Err(Error::msg(error_msg));
             }
         };
 
         let arr: Vec<&str> = contents_str.trim().split_whitespace().collect();
         let checksum_init = arr[0];
         let file_name = PathBuf::from(arr[1]);
-
-        let mut contents_input = Vec::new();
+        let mut contents_input: Vec<u8> = Vec::new();
 
         match File::open(&file_name) {
             Ok(mut file) => {
                 if let Err(e) = file.read_to_end(&mut contents_input) {
                     eprintln!("Error reading file {}: {}", file_name.display(), e);
-                    return ExitCode::FAILURE;
                 }
             }
             Err(e) => {
-                eprintln!("Error opening file {}: {}", file_name.display(), e);
-                return ExitCode::FAILURE;
+                let error_msg = format!("Error opening file {}: {}", file_name.display(), e);
+                return Err(Error::msg(error_msg));
             }
         }
 
@@ -75,10 +68,12 @@ fn main() -> ExitCode {
 
         if checksum_init == calculated_checksum {
             println!("{}: OK", file_name.display());
+            return Ok(());
         } else {
             eprintln!("{}: FAILED", file_name.display());
-            eprintln!("sha256sum-win: WARNING: 1 computed checksum did NOT match");
+            let error_msg =
+                String::from("sha256sum-win: WARNING: 1 computed checksum did NOT match");
+            return Err(Error::msg(error_msg));
         }
     }
-    ExitCode::SUCCESS
 }


### PR DESCRIPTION
Refactor error handling in main.rs

  - Replace direct calls to `eprintln!` with `Error::msg` for consistent error reporting.
  - Return a `Result` instead of `ExitCode` to reflect the potential for errors.