### PR TITLE
0.3.0: 16th May 2024

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,6 +30,6 @@ If applicable, add screenshots to help explain your problem.
 ## Environment
 
 - OS: [e.g., Windows 10]
-- `sha256sum-win` Version: [e.g., 1.0.0]
+- `steadyhash` Version: [e.g., 1.0.0]
 - Additional context or information that might be relevant.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[Unreleased\]
+## [Unreleased]
 
-## \[0.2.0\] - 2024-03-17
+## [0.3.0] - 2024-03-17
+
+### Changed
+
+  - Use `thiserror` for internal functions, and use `anyhow` for the main
+    function.
+  - Update Cargo.toml to get better executables and update version.
+  - Update the issue templates to match the project's name.
+  - Update dependencies in Cargo.lock
+  - Move hashing files to a new module
 
 ### Added
 
-  - Add using SHA256, SHA512 and SHA1 checksums.
+  - Add support for Blake2b-256 and Blake2b-512.
+
+### Removed
+
+  - Remove checking for checksum files.
+
+## [0.2.0] - 2024-03-17
+
+### Added
+
+  - Add SHA256, SHA512 and SHA1 checksums.
 
 ### Changed
 
   - Changed the project name from `sha256sum-win-rs` to `steadyhash-rs`.
   - Switch from using the `structopt` crate to `clap`, as it's more updated.
 
-## \[0.1.1\] - 2023-12-08
+## [0.1.1] - 2023-12-08
 
 ### Added
 
@@ -31,7 +50,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   - Switched from using the `openssl` crate to `sha2` one, as `sha2` is more
     lightweight.
 
-## \[0.1.0\] - 2023-12-03
+## [0.1.0] - 2023-12-03
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,47 +4,48 @@ version = 3
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -52,9 +53,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "25bdb32cbbdce2b519a9cd7df3a678443100e265d5e25ca763b7572a5104f5f3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "block-buffer"
@@ -73,9 +83,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -95,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -113,9 +123,9 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "cpufeatures"
@@ -144,6 +154,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -163,25 +174,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "libc"
-version = "0.2.153"
+name = "is_terminal_polyfill"
+version = "1.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
+name = "libc"
+version = "0.2.154"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -209,30 +226,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "steadyhash-rs"
-version = "0.1.0"
+name = "steadyhash"
+version = "0.3.0"
 dependencies = [
  "anyhow",
+ "blake2",
  "clap",
  "sha1",
  "sha2",
+ "thiserror",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "bf5be731623ca1a1fb7d8be6f261a3be6d3e2337b8a1f97be944d020c8fcb704"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -270,13 +315,14 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
+ "windows_i686_gnullvm",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
@@ -285,42 +331,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,26 @@
 [package]
-name = "steadyhash-rs"
-version = "0.1.0"
+name = "steadyhash"
+version = "0.3.0"
 edition = "2021"
+license = "GPL-3.0"
+categories = ["command-line-utilities", "cryptography"]
+keywords = ["command-line", "cli", "integrity-checker"]
+readme = "README.md"
+repository = "https://github.com/walker84837/steadyhash-rs"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.dev]
+debug = false
+
+[profile.release]
+strip = true
+lto = true
+overflow-checks = true
+panic = "abort"
 
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5.3", features = ["derive"] }
 sha2 = "0.10"
 sha1 = "0.10.6"
+thiserror = "1.0.60"
+blake2 = "0.10.6"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # steadyhash: reliable file integrity checker
 
-SteadyHash provides a straightforward way to handle SHA-1, SHA-256, and SHA-512
-checksums. It allows users to generate checksums for files and also verify
-checksums against provided values.
+SteadyHash provides a straightforward way to generate and verify SHA-1, SHA-256,
+and SHA-512 checksums.
 
 ## Usage
 
@@ -20,13 +19,16 @@ To use this utility, follow these steps:
 
 To generate a checksum for a file, use the following command:
 
-Usage: steadyhash \[OPTIONS\] --type \<CHECKSUM\> \[FILEs\]...
+Usage: `steadyhash [OPTIONS] --type <CHECKSUM> [FILEs]...`
 
-Arguments: \[FILEs\]... : the files to process
+Arguments: `[FILEs]... : the files to process`
 
 Options:
 
-  - `-t, --type`: the type of SHA checksum (1, 256, 512)
+  - `-t, --type`: the type of SHA checksum. Possible valeus are:
+      - 1 (SHA-1)
+      - 256 (SHA-256)
+      - 512 (SHA-512)
   - `-c, --check`: read checksums from the FILEs and check them
   - `--tag`: create a BSD-style checksum
   - `--binary`: read in binary mode
@@ -44,9 +46,10 @@ $ steadyhash --check --type [CHECKSUM_TYPE] [FILE_PATH]
 
 ## Roadmap
 
-  - [ ] Support for multiple platforms (as of now only Unix-like are supported)
-  - [ ] Support for checking BSD-style checksums
-  - [ ] Configuration (maybe)
+  - \[X\] Support for multiple platforms (as of now only Unix-like are
+    supported)
+  - \[ \] Support for checking BSD-style checksums
+  - \[ \] Configuration (maybe)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # steadyhash: reliable file integrity checker
 
 SteadyHash provides a straightforward way to generate and verify SHA-1, SHA-256,
-and SHA-512 checksums.
+SHA-512, Blake2b-512 and Blake2b-256 checksums.
 
 ## Usage
 
@@ -25,36 +25,53 @@ Arguments: `[FILEs]... : the files to process`
 
 Options:
 
-  - `-t, --type`: the type of SHA checksum. Possible valeus are:
-      - 1 (SHA-1)
-      - 256 (SHA-256)
-      - 512 (SHA-512)
-  - `-c, --check`: read checksums from the FILEs and check them
+  - `-t, --type`: the type of SHA checksum. Possible values are:
+    - `sha`
+    - `blake`
+    - `b2`
+    - `blake2`
+  - `-l, --length`: the bit length of the checksum:
+    - The valid values for `sha` are:
+        - `160`
+        - `256`
+        - `512`
+    - The valid values for `blake` are:
+        - `256`
+        - `512`
+  - `-c, --check`: read checksums from the FILEs and check them (unimplemented)
   - `--tag`: create a BSD-style checksum
-  - `--binary`: read in binary mode
+  - `--binary`: read in binary mode (does nothing)
   - `-s, --stdin`: read data from stdin
   - `-h, --help`: print help
   - `-V, --version`: print version
 
-### Verifying checksums
+#### Examples
 
-To verify a checksum against a file, use the following command:
+  - Generate a SHA256 BSD-style checksum:
+    ```console
+    $ steadyhash -l 256 -t sha foo.bar
+    ```
 
-``` console
-$ steadyhash --check --type [CHECKSUM_TYPE] [FILE_PATH]
-```
+  - Generate a Blake2b-256 checksum:
+    ```console
+    $ steadyhash -l 256 -t b2 foo.bar
+    ```
+
+  - Generate a SHA1 BSD-style checksum:
+    ```console
+    $ steadyhash -l 160 -t sha --tag foo.bar
+    ````
 
 ## Roadmap
 
-  - \[X\] Support for multiple platforms (as of now only Unix-like are
-    supported)
-  - \[ \] Support for checking BSD-style checksums
-  - \[ \] Configuration (maybe)
+  - [X] Support for multiple platforms
+  - [ ] Support for checking checksums
+  - [ ] Configuration (maybe)
 
 ## Support
 
 If you encounter any issues or have questions about this utility, feel free to
-[open an issue](https://github.com/walker84837/steadyhash-rs/issues).
+[open an issue](https://github.com/walker84837/steadyhash/issues).
 
 ## License
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,23 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ShaSumError {
+    /// Error indicating that an invalid SHA checksum type has been provided.
+    #[error("Invalid checksum type 'SHA-{0}'. The only supported types are SHA1, SHA256 and SHA512")]
+    InvalidChecksumType(i32),
+
+    /// Error indicating that something went wrong when it shouldn't. Alternative to panic!()
+    #[error("Something went unexpectedly wrong: {0}.")]
+    UnexpectedError(String),
+}
+
+#[derive(Error, Debug)]
+pub enum B2SumError {
+    /// Error indicating that an invalid Blake checksum type has been provided. 
+    #[error("Invalid checksum type 'Blake2b-{0}'. The only supported types are Blake2b-256 and Blake2b-512.")]
+    InvalidChecksumType(i32),
+
+    /// Error indicating that something went wrong when it shouldn't. Alternative to panic!()
+    #[error("Something went unexpectedly wrong: {0}.")]
+    UnexpectedError(String),
+}

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -44,13 +44,14 @@ impl ShaSum<'_> {
 }
 
 mod tests {
-    use crate::ShaSum;
+    #[allow(unused_imports)]
+    use super::*;
 
     #[test]
     fn test_sha512sum() {
         let data = b"i use arch btw\n";
 
-        let mut checksummer = ShaSum::new(512, data).unwrap();
+        let checksummer = ShaSum::new(512, data).unwrap();
 
         // echo 'i use arch btw' | sha512sum -b
         let expected_checksum = "2ddbe9f9af5a630d3734ce469fac19088e8d0242541768630777de5c56dc4053d346a67527cb95de3ab094d6862f393392ba26bed459d9ad149b423aeae552a2"
@@ -76,7 +77,7 @@ mod tests {
     fn test_sha1sum() {
         let data = b"i use arch btw\n";
 
-        let mut checksummer = ShaSum::new(1, data).unwrap();
+        let checksummer = ShaSum::new(1, data).unwrap();
 
         let expected_checksum = "821609590ef05d00b20c5f4c5a28c56627480eb7".to_owned();
 

--- a/src/hashing/blake2b.rs
+++ b/src/hashing/blake2b.rs
@@ -1,0 +1,46 @@
+use crate::errors::B2SumError;
+use blake2::{Blake2b512, Blake2s256, Digest};
+
+pub struct Blake2b<'a> {
+    /// Bit length of the checksum
+    checksum_type: i32,
+
+    /// Data to process
+    data: &'a [u8],
+}
+
+impl Blake2b<'_> {
+    pub fn new(checksum_type: i32, data: &[u8]) -> Result<Blake2b<'_>, B2SumError> {
+        if ![256, 512].contains(&checksum_type) {
+            return Err(B2SumError::InvalidChecksumType(checksum_type));
+        }
+
+        Ok(Blake2b {
+            checksum_type,
+            data,
+        })
+    }
+
+    pub fn get_checksum(&self) -> Result<String, B2SumError> {
+        match self.checksum_type {
+            512 => {
+                let mut hasher = Blake2b512::new();
+                hasher.update(self.data);
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            256 => {
+                let mut hasher = Blake2s256::new();
+                hasher.update(self.data);
+                Ok(format!("{:x}", hasher.finalize()))
+            }
+            _ => Err(B2SumError::UnexpectedError(
+                "invalid b2sum type".to_string(),
+            )),
+        }
+    }
+}
+
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+}

--- a/src/hashing/mod.rs
+++ b/src/hashing/mod.rs
@@ -1,0 +1,2 @@
+pub mod blake2b;
+pub mod shasum;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,30 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use std::{
     fs::File,
-    io::{self, BufRead, BufReader, Read},
-    path::{Path, PathBuf}
+    io::{self, BufReader, Read},
+    path::{Path, PathBuf},
 };
 
+mod errors;
 mod hashing;
-use hashing::ShaSum;
+use hashing::{blake2b::Blake2b, shasum::ShaSum};
 
 #[derive(Parser)]
 #[clap(
     version,
-    about = "Pure Rust utility which handles SHA-2 and SHA-1 checksums"
+    about = "Pure Rust utility which handles various checksum types"
 )]
 struct Args {
+    #[clap(short = 'l', long = "length", help = "the bit length of the checksum")]
+    bit_length: i32,
+
     #[clap(
         short = 't',
         long = "type",
-        name = "CHECKSUM",
-        help = "the type of SHA checksum (1, 256, 512)"
+        help = "the type of checksum (sha or blake)"
     )]
-    checksum_type: i32,
+    checksum_type: String,
 
     #[clap(name = "FILEs", help = "the files to process")]
     file_path: Vec<PathBuf>,
@@ -39,25 +42,11 @@ struct Args {
     stdin: bool,
 }
 
-trait ReadToEnd {
-    fn read_to_end_slice(&mut self) -> Result<Vec<u8>>;
-}
-
-impl<R: Read> ReadToEnd for BufReader<R> {
-    fn read_to_end_slice(&mut self) -> Result<Vec<u8>> {
-        let mut tmp: Vec<u8> = Vec::new();
-        self.read_to_end(&mut tmp)?;
-        Ok(tmp)
-    }
-}
-
 /// Get the file name in a path, like the `basename` Linux command
 fn basename(file: &Path) -> Result<String> {
     Ok(file
-        .to_path_buf()
         .file_name()
         .ok_or_else(|| anyhow!("File doesn't exist."))?
-        .to_os_string()
         .to_string_lossy()
         .into_owned()
         .chars()
@@ -71,80 +60,56 @@ fn main() -> Result<()> {
     for file in &args.file_path {
         let mut contents = Vec::new();
 
-        if args.stdin {
-            io::stdin().read_to_end(&mut contents)?;
-        } else {
+        if !args.stdin {
             let mut reader = BufReader::new(File::open(file)?);
             if args.binary {
-                contents.extend(reader.bytes().flatten());
+                reader.read_to_end(&mut contents)?;
             } else {
                 reader.read_to_end(&mut contents)?;
             }
+        } else {
+            io::stdin().read_to_end(&mut contents)?;
         }
 
-        let checksum = match args.checksum_type {
-            1 | 256 | 512 => {
-                let checksummer = ShaSum::new(args.checksum_type, &contents)?;
-                checksummer.get_checksum()
-            }
-            _ => return Err(anyhow!("Invalid type: {}", args.checksum_type)),
-        };
+        match args.checksum_type.as_str() {
+            "sha" => {
+                let hasher = ShaSum::new(args.bit_length, &contents)?;
+                let checksum = hasher.get_checksum()?;
 
-        let file_path_checksum = basename(file)?;
+                let r#type = if args.bit_length == 160 {
+                    1
+                } else {
+                    args.bit_length
+                };
 
-        if args.check {
-            let expected_checksum = read_expected_checksum(&checksum, file, args.bsd)?;
-            if checksum == expected_checksum {
-                println!("{}: OK", file_path_checksum);
-            } else {
-                println!("{}: MISMATCH", file_path_checksum);
+                if args.bsd {
+                    println!(
+                        "SHA{} ({}) = {}",
+                        r#type,
+                        basename(&file)?,
+                        checksum
+                    );
+                } else {
+                    println!("{} {}", checksum, basename(&file)?);
+                }
             }
-        } else if args.bsd {
-            println!(
-                "SHA{} ({}) = {}",
-                args.checksum_type, file_path_checksum, checksum
-            );
-        } else {
-            println!("{}  {}", checksum, file_path_checksum);
+            "blake" | "b2" | "blake2" => {
+                let hasher = Blake2b::new(args.bit_length, &contents)?;
+                let checksum = hasher.get_checksum()?;
+                if args.bsd {
+                    println!(
+                        "BLAKE2b-{} ({}) = {}",
+                        args.bit_length,
+                        basename(&file)?,
+                        checksum
+                    );
+                } else {
+                    println!("{}  {}", checksum, basename(&file)?);
+                }
+            }
+            _ => bail!("Invalid checksum type. Possible values are `sha` or `blake`."),
         }
     }
 
     Ok(())
-}
-
-fn read_expected_checksum(
-    calculated_checksum: &str,
-    file_path: &PathBuf,
-    bsd: bool,
-) -> Result<String> {
-    let file = File::open(file_path)?;
-    let reader = BufReader::new(file);
-
-    if bsd {
-        for line in reader.lines() {
-            let line = line?;
-            if line.starts_with(&format!(
-                "SHA{} ({} )= ",
-                calculated_checksum.len() * 8,
-                file_path.display()
-            )) {
-                return Ok(line
-                    .trim_start_matches(&format!(
-                        "SHA{} ({}) = ",
-                        calculated_checksum.len() * 8,
-                        file_path.display()
-                    ))
-                    .to_string());
-            }
-        }
-    } else {
-        for line in reader.lines() {
-            let line = line?;
-            let parts: Vec<&str> = line.split_whitespace().collect();
-            if parts.len() == 2 && parts[1] == file_path.to_string_lossy() {
-                return Ok(parts[0].to_string());
-            }
-        }
-    }
-    Err(anyhow!("Checksum not found for file: {:?}", file_path))
 }


### PR DESCRIPTION
### Changed

  - Use `thiserror` for internal functions, and use `anyhow` for the main function.
  - Update Cargo.toml to get better executables and update version.
  - Update the issue templates to match the project's name.
  - Update dependencies in Cargo.lock
  - Move hashing files to a new module

### Added

  - Add support for Blake2b-256 and Blake2b-512.

### Removed

  - Remove checking for checksum files.